### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Abderraouf Adjal <abderraouf.adjal@gmail.com>
 maintainer=Abderraouf Adjal <abderraouf.adjal@gmail.com>
 sentence=Spritz cipher library, Random bytes generator, Hash & MAC.
 paragraph=Spritz cipher library, A spongy RC4-like stream cipher. This library contains cryptographically secure RNG, Hash & MAC with configurable output length.
+category=Data Processing
 url=https://github.com/abderraouf-adjal/ArduinoSpritzCipher
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library SpritzCipher is not valid.
Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.
